### PR TITLE
Introduce Scanner interface as an abstraction for Clamd struct

### DIFF
--- a/clamd.go
+++ b/clamd.go
@@ -319,7 +319,7 @@ func (c *Clamd) ScanStream(r io.Reader, abort chan bool) (chan *ScanResult, erro
 	return ch, nil
 }
 
-func NewClamd(address string) *Clamd {
+func NewClamd(address string) Scanner {
 	clamd := &Clamd{address: address}
 	return clamd
 }

--- a/clamd.go
+++ b/clamd.go
@@ -40,6 +40,20 @@ const (
 	RES_PARSE_ERROR = "PARSE ERROR"
 )
 
+type Scanner interface {
+	Ping() error
+	Version() (chan *ScanResult, error)
+	Stats() (*Stats, error)
+	Reload() error
+	Shutdown() error
+	ScanFile(path string) (chan *ScanResult, error)
+	RawScanFile(path string) (chan *ScanResult, error)
+	MultiScanFile(path string) (chan *ScanResult, error)
+	ContScanFile(path string) (chan *ScanResult, error)
+	AllMatchScanFile(path string) (chan *ScanResult, error)
+	ScanStream(r io.Reader, abort chan bool) (chan *ScanResult, error)
+}
+
 type Clamd struct {
 	address string
 }


### PR DESCRIPTION
For testing purposes I would like to have an interface as an abstraction from Clamd.

Pull Request is just adding the interface without changing any logic.

The name `Scanner` can be discussed but I think that it represents the methods inside of the interface.