### PR TITLE
Add support for excluded file paths

### DIFF
--- a/clamd.go
+++ b/clamd.go
@@ -36,6 +36,7 @@ import (
 const (
 	RES_OK          = "OK"
 	RES_FOUND       = "FOUND"
+	RES_EXCLUDED    = "Excluded"
 	RES_ERROR       = "ERROR"
 	RES_PARSE_ERROR = "PARSE ERROR"
 )

--- a/conn.go
+++ b/conn.go
@@ -41,7 +41,7 @@ const CHUNK_SIZE = 1024
 const TCP_TIMEOUT = time.Second * 2
 
 var resultRegex = regexp.MustCompile(
-	`^(?P<path>[^:]+): ((?P<desc>[^:]+)(\((?P<virhash>([^:]+)):(?P<virsize>\d+)\))? )?(?P<status>FOUND|ERROR|OK)$`,
+	`^(?P<path>[^:]+): ((?P<desc>[^:]+)(\((?P<virhash>([^:]+)):(?P<virsize>\d+)\))? )?(?P<status>FOUND|ERROR|OK|Excluded)$`,
 )
 
 type CLAMDConn struct {
@@ -140,6 +140,7 @@ func parseResult(line string) *ScanResult {
 			switch matches[i] {
 			case RES_OK:
 			case RES_FOUND:
+			case RES_EXCLUDED:
 			case RES_ERROR:
 				break
 			default:


### PR DESCRIPTION
Thank you for the library, we make use of it for some scanning needs.

In our `clamd.conf` we exclude some paths but while parsing the results those files show as failed to due to the fact that `go-clamd` does not have support for parsing lines with `Excluded` in them.