### PR TITLE
Allow changing chunk size for ScanStream

### DIFF
--- a/clamd.go
+++ b/clamd.go
@@ -259,7 +259,7 @@ the actual chunk. Streaming is terminated by sending a zero-length chunk. Note:
 do not exceed StreamMaxLength as defined in clamd.conf, otherwise clamd will
 reply with INSTREAM size limit exceeded and close the connection
 */
-func (c *Clamd) ScanStream(r io.Reader, abort chan struct{}) (chan *ScanResult, error) {
+func (c *Clamd) ScanStream(r io.Reader, abort <-chan struct{}) (chan *ScanResult, error) {
 	conn, err := c.newConnection()
 	if err != nil {
 		return nil, err

--- a/clamdBuilder.go
+++ b/clamdBuilder.go
@@ -1,0 +1,30 @@
+package clamd
+
+type Builder struct {
+	address   string
+	chunkSize int
+}
+
+func NewBuilder() *Builder {
+	return &Builder{
+		address:   "",
+		chunkSize: CHUNK_SIZE,
+	}
+}
+
+func (b *Builder) WithAddress(address string) *Builder {
+	b.address = address
+	return b
+}
+
+func (b *Builder) WithChunkSize(chunkSize int) *Builder {
+	b.chunkSize = chunkSize
+	return b
+}
+
+func (b *Builder) Build() *Clamd {
+	return &Clamd{
+		address:   b.address,
+		chunkSize: b.chunkSize,
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/dutchcoders/go-clamd
+
+go 1.22.4


### PR DESCRIPTION
Added chunkSize parameter to Clamd struct which is used now instead of the default value of 1024.

Also replaced the abort channel with type struct{} so it can be used out of the box with the ctx.Done() channel.

Added a builder to not change the function signatures for Clamd and added a module file.